### PR TITLE
Added method for stun request on existing conn

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -3,7 +3,7 @@ set -e
 
 # Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github "
+EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github --exclude-dir=test"
 DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(' 'fmt.Println(' 'fmt.Printf(' 'log.Print(' 'log.Println(' 'log.Printf(')
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+### JetBrains IDE ###
+#####################
+.idea/
+
+### Emacs Temporary Files ###
+#############################
+*~
+
+### Folders ###
+###############
+bin/
+vendor/
+node_modules/
+
+### Files ###
+#############
+tags
+cover.out
+*.sw[poe]
+*.wasm

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - gocritic
     - gochecknoinits
     - gochecknoglobals
+    - interfacer
 
 issues:
   exclude-use-default: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ notifications:
     secure: neajsJrsYjNFAnDQA9et0yXDgcTeNDVJRf1Py7KceW/s8O23jN/qYWmQ/l3JjUJ2ce58xfH4BqIRFrmZYB06j8t+RfaYm26QMlzQOelXQN46Ll0ScYFSpdjShiyjrazlV2CNDUQJ1EVxX0R0zij9zON3rT/r37QSRD1gnHyE/rw4w1gOo3Ur7sRgw7Y9kJqoGbHZo0AsCnvScm8ChWXt+2EoQmQ+CxB1+rTmX/1F0J6g1Rdz/AsTfbDge1i/J12FdLgG5mgBXweF+VSYIRxxwJkvrxTnrKFI4jUvj8IqF/TIF6Z/2Cks6bBg1fnGMoRmc9qTf5tbfRUKxziRTYw0d2tqIfm+7bFQbPh/8q9IDivgNQdI+Fgzte7r4goKVVs//5ueXUewOFXeLovGutCRt8SBBN2iPyu3Dcwa3yYqwEdOBdFfW/k9hSBBHH5a71x6TA2B3JxFdASrZxdqj1kV3PJsjAchpwz6zBD7tp5/KWqTY0jzQU9QV+zjOiGZyo6POsDN7zGDjcbeUqrVrw/mmNfef7IV7U1/RhLJXtULcvljHGJ9c2DXhusIiyDr4TPC6A/wyFtkVQ5WXfaruWZmHh0v2CFmIYMk4qEDT7BSZuPWFQuEpHA+yjN5LUi1h5xTBGHazQCN3KRx2QiRA8iBQkJINq0yb/ecDTXDqWIdKQs=
 
 before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.12.5
   - go get github.com/mattn/goveralls
 

--- a/client_test.go
+++ b/client_test.go
@@ -2,8 +2,12 @@ package stun
 
 import (
 	"fmt"
+	"net"
 	"testing"
 	"time"
+
+	"github.com/pion/stun/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_Request(t *testing.T) {
@@ -35,5 +39,74 @@ func TestClient_Request(t *testing.T) {
 		}
 		fmt.Printf("remote address: %s:%d\n", addr.IP.String(), addr.Port)
 		fmt.Printf("local address: %s\n", client.conn.LocalAddr().String())
+	}
+}
+
+func TestGetMappedAddress(t *testing.T) {
+	for _, data := range []struct {
+		name       string
+		network    string
+		localIP    string
+		remoteIP   string
+		remotePort int
+	}{
+		{
+			name:       "udp4",
+			network:    "udp4",
+			localIP:    "127.0.0.1",
+			remoteIP:   "1.2.3.4",
+			remotePort: 1234,
+		},
+		{
+			name:       "udp6",
+			network:    "udp6",
+			localIP:    "[::1]",
+			remoteIP:   "c031:ca06:a453:e56d:cda:7122:a1d7:b01b",
+			remotePort: 1234,
+		},
+	} {
+		d := data
+		t.Run(d.name, func(t *testing.T) {
+			serverAddr, closeServer, err := test.NewUDPServer(
+				t,
+				d.network,
+				maxMessageSize,
+				func(req []byte) ([]byte, error) {
+					msg, err := NewMessage(req)
+					if err != nil {
+						return nil, err
+					}
+
+					resp, err := Build(ClassSuccessResponse, MethodBinding, msg.TransactionID,
+						&XorMappedAddress{XorAddress: XorAddress{IP: net.ParseIP(d.remoteIP), Port: d.remotePort}},
+					)
+					if err != nil {
+						return nil, err
+					}
+
+					return resp.Pack(), nil
+				})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer closeServer(t)
+
+			conn, err := net.ListenUDP(d.network, &net.UDPAddr{IP: net.ParseIP(d.localIP), Port: 0})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			xoraddr, err := GetMappedAddressUDP(
+				conn,
+				serverAddr,
+				time.Second*1,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, d.remoteIP, xoraddr.IP.String())
+			assert.Equal(t, d.remotePort, xoraddr.Port)
+		})
 	}
 }

--- a/test/udp_server.go
+++ b/test/udp_server.go
@@ -1,0 +1,80 @@
+package test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+// NewUDPServer creates an udp server for testing. The supplied handler function will be called with the request
+// and should be used to emulate the server behavior.
+func NewUDPServer(
+	t *testing.T,
+	network string,
+	maxMessageSize int,
+	handler func(req []byte) ([]byte, error),
+) (net.Addr, func(t *testing.T), error) {
+	var ip string
+	switch network {
+	case "udp4":
+		ip = "127.0.0.1"
+	case "udp6":
+		ip = "[::1]"
+	default:
+		return nil, nil, fmt.Errorf("unsupported network: %s", network)
+	}
+
+	udpConn, err := net.ListenUDP(network, &net.UDPAddr{IP: net.ParseIP(ip), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// necessary for ipv6
+	address := fmt.Sprintf("%s:%d", ip, udpConn.LocalAddr().(*net.UDPAddr).Port)
+	serverAddr, err := net.ResolveUDPAddr(network, address)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve stun host: %s: %v", address, err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		for {
+			bs := make([]byte, maxMessageSize)
+			n, addr, err := udpConn.ReadFrom(bs)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			resp, err := handler(bs[:n])
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			_, err = udpConn.WriteTo(resp, addr)
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	return serverAddr, func(t *testing.T) {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+		default:
+		}
+
+		err := udpConn.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		<-errCh
+	}, nil
+}


### PR DESCRIPTION
Instead of creating a new connection for the stun host/ip, added a
method to use an existing connection for communicating with the stun
server.

#### Reference issue
Fixes https://github.com/pion/webrtc/issues/668
