### PR TITLE
Message buffer usage optimization

### DIFF
--- a/message.go
+++ b/message.go
@@ -106,9 +106,11 @@ func (m *Message) Reset() {
 
 // grow ensures that internal buffer has n length.
 func (m *Message) grow(n int) {
-	for len(m.Raw) < n {
-		m.Raw = append(m.Raw, 0)
+	if cap(m.Raw) >= n {
+		m.Raw = m.Raw[:n]
+		return
 	}
+	m.Raw = append(m.Raw, make([]byte, n-len(m.Raw))...)
 }
 
 // Add appends new attribute to message. Not goroutine-safe.

--- a/message.go
+++ b/message.go
@@ -104,17 +104,11 @@ func (m *Message) Reset() {
 	m.Attributes = m.Attributes[:0]
 }
 
-// grow ensures that internal buffer will fit v more bytes and
-// increases it capacity if necessary.
-func (m *Message) grow(v int) {
-	// Not performing any optimizations here
-	// (e.g. preallocate len(buf) * 2 to reduce allocations)
-	// because they are already done by []byte implementation.
-	n := len(m.Raw) + v
-	for cap(m.Raw) < n {
+// grow ensures that internal buffer has n length.
+func (m *Message) grow(n int) {
+	for len(m.Raw) < n {
 		m.Raw = append(m.Raw, 0)
 	}
-	m.Raw = m.Raw[:n]
 }
 
 // Add appends new attribute to message. Not goroutine-safe.

--- a/message.go
+++ b/message.go
@@ -106,6 +106,9 @@ func (m *Message) Reset() {
 
 // grow ensures that internal buffer has n length.
 func (m *Message) grow(n int) {
+	if len(m.Raw) >= n {
+		return
+	}
 	if cap(m.Raw) >= n {
 		m.Raw = m.Raw[:n]
 		return

--- a/message_test.go
+++ b/message_test.go
@@ -472,7 +472,7 @@ func TestMessage_Equal(t *testing.T) {
 func TestMessageGrow(t *testing.T) {
 	m := New()
 	m.grow(512)
-	if len(m.Raw) < 532 {
+	if len(m.Raw) < 512 {
 		t.Error("Bad length", len(m.Raw))
 	}
 }
@@ -480,10 +480,10 @@ func TestMessageGrow(t *testing.T) {
 func TestMessageGrowSmaller(t *testing.T) {
 	m := New()
 	m.grow(2)
-	if cap(m.Raw) < 22 {
+	if cap(m.Raw) < 20 {
 		t.Error("Bad capacity", cap(m.Raw))
 	}
-	if len(m.Raw) < 22 {
+	if len(m.Raw) < 20 {
 		t.Error("Bad length", len(m.Raw))
 	}
 }

--- a/textattrs.go
+++ b/textattrs.go
@@ -124,6 +124,6 @@ func (v *TextAttribute) GetFromAs(m *Message, t AttrType) error {
 	if err != nil {
 		return err
 	}
-	*v = append((*v)[:0], a...)
+	*v = a
 	return nil
 }


### PR DESCRIPTION
While retrospectively reviewing the stun library I've discovered some things that I've missed during refactoring iterations.

1) The `grow` method actual usage expects different implementation.
2) Text attributes like `Nonce` are doing implicit copy instead of referencing the original buffer.

This PR addresses both issues. I see no backward incompatible changes except probable misuse of text attributes, e.g. using decoded `Nonce` after corresponding `m.Raw` is invalidated and reused.

The 1 will optimize memory allocation and fix possible unexpectedly big `m.Raw`-s, the 2 speed-up the `Nonce`, `Username` and other text attributes decode time and memory consumption.