### PR TITLE
Constrain stun-client to use IPv4

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Will LE](https://github.com/bixycler)
 * [David-dp-](https://github.com/David-dp-)
 * [ZHENK](https://github.com/scorpionknifes)
+* [Juliusz Chroboczek](https://github.com/jech)
 
 # STUN
 Package stun implements Session Traversal Utilities for NAT (STUN) [[RFC5389](https://tools.ietf.org/html/rfc5389)]

--- a/cmd/stun-client/stun_client.go
+++ b/cmd/stun-client/stun_client.go
@@ -19,7 +19,8 @@ func main() {
 	if addr == "" {
 		addr = "stun.l.google.com:19302"
 	}
-	c, err := stun.Dial("udp", addr)
+	// we only try the first address, so restrict ourselves to IPv4
+	c, err := stun.Dial("udp4", addr)
 	if err != nil {
 		log.Fatal("dial:", err)
 	}


### PR DESCRIPTION
The function stun.Dial only tries the first address; for a
double-stack host (IPv4 and IPv6), this will be an IPv6 address,
which will either provide useless information (the global IPv6
address, which is already known), or will hang if the STUN server
is IPv4-only.

Fixes #70.
