### PR TITLE
nat-behaviour: fix filtering test

### DIFF
--- a/cmd/stun-nat-behaviour/main.go
+++ b/cmd/stun-nat-behaviour/main.go
@@ -170,7 +170,7 @@ func filteringTests(addrStr string) error {
 
 	// Test II: Request to change both IP and port
 	log.Info("Filtering Test II: Request to change both IP and port")
-	request.Reset()
+	request = stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	request.Add(stun.AttrChangeRequest, []byte{0x00, 0x00, 0x00, 0x06})
 
 	resp, err = mapTestConn.roundTrip(request, mapTestConn.RemoteAddr)
@@ -184,7 +184,7 @@ func filteringTests(addrStr string) error {
 
 	// Test III: Request to change port only
 	log.Info("Filtering Test III: Request to change port only")
-	request.Reset()
+	request = stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	request.Add(stun.AttrChangeRequest, []byte{0x00, 0x00, 0x00, 0x02})
 
 	resp, err = mapTestConn.roundTrip(request, mapTestConn.RemoteAddr)


### PR DESCRIPTION
#### Description

This PR fixes filtering tests of cmd/stun-nat-behaviour utility. Previously it reused STUN message structure and updated it with .Reset(). It causes message missing header and proper request type. Consequently, such messages were not recognized by stun servers and they did not respond. Lack of response was always considered to be an "address and port dependent filtering".

Instead of duplicating Message.Build() logic with .WriteHeader() and other internals, I've just reused common approach creating STUN message everywhere.