### PR TITLE
Update installation instruction for Go >= v1.17.0

### DIFF
--- a/cmd/stun-multiplex/README.md
+++ b/cmd/stun-multiplex/README.md
@@ -5,7 +5,7 @@ that splits incoming UDP packets to two streams, "STUN Data" and "Application Da
 
 Usage:
 ```sh
-$ go get github.com/pion/stun/cmd/stun-multiplex
+$ go install github.com/pion/stun/cmd/stun-multiplex@latest
 ```
 
 On "server":

--- a/cmd/stun-nat-behaviour/README.md
+++ b/cmd/stun-nat-behaviour/README.md
@@ -8,7 +8,7 @@ behaviour.
 
 ### Usage
 ```sh
-$ go get github.com/pion/stun/cmd/stun-nat-behaviour
+$ go install github.com/pion/stun/cmd/stun-nat-behaviour@latest
 $ $GOPATH/bin/stun-nat-behaviour [options] [--server IP:port]
 ```
 


### PR DESCRIPTION
#### Description
The installation documentation mention `go get` as the command to install the executable,
which was deprecated with Go v1.17.0 and will lead to an error.

```
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

#### Reference issue
Assuming that PR #118 might be implemented, the command to install executables should be
amended to `go install`.

PR #118 should be taken into account as the compilation with Go v.1.12.0 will lead to an
error.

```
# github.com/pion/stun
go/1.12.0/src/github.com/pion/stun/checks.go:36:9: undefined: errors.Is
go/1.12.0/src/github.com/pion/stun/checks.go:49:9: undefined: errors.Is
go/1.12.0/src/github.com/pion/stun/client.go:162:5: undefined: errors.Is
go/1.12.0/src/github.com/pion/stun/client.go:331:31: undefined: errors.Is
go/1.12.0/src/github.com/pion/stun/client.go:339:19: undefined: errors.Is
go/1.12.0/src/github.com/pion/stun/client.go:536:27: undefined: errors.Is
```

PS: Please let me know if I missed some step for contribution. But the offered link to [CONTRIBUTING.md](https://github.com/pion/.github/blob/8462baa35818504cbd51c9432521b23508a0e3a8/CONTRIBUTING.md) mention to check https://pion.ly/knowledge-base/pion-internals/. That link end with a HTTP 404 error.