### PR TITLE
Remove Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM golang:1.19
-
-COPY . /go/src/github.com/pion/stun
-
-RUN go test github.com/pion/stun

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,6 @@ install-fuzz:
 install:
 	go get gortc.io/api
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-docker-build:
-	docker build -t pion/stun .
 test-integration:
 	@cd e2e && bash ./test.sh
 prepush: assert test lint test-integration

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,9 @@ install:
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 test-integration:
 	@cd e2e && bash ./test.sh
-prepush: assert test lint test-integration
+prepush: test lint test-integration
 check-api:
 	@cd api && bash ./check.sh
-assert:
-	bash .github/assert-contributors.sh
-	bash .github/lint-disallowed-functions-in-library.sh
-	bash .github/lint-commit-message.sh
 test:
 	@./go.test.sh
 clean:


### PR DESCRIPTION
The Dockerfile does not serve any useful purpose.
It also deviates from pions goassets. And hence,
in an effort to harmonize the pion codebase we
should remove it.