### PR TITLE
Remove repo-specific codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,0 @@
-coverage:
-  status:
-    patch: off
-    project:
-      default:
-        # basic
-        target: 98
-        threshold: null
-        base: auto


### PR DESCRIPTION
We have an org-wide codecov in pion/.goassets which should be used instead