### PR TITLE
Fix `is-server` being ignored in stun-multiplex

### DIFF
--- a/cmd/stun-multiplex/main.go
+++ b/cmd/stun-multiplex/main.go
@@ -85,9 +85,9 @@ func multiplex(conn *net.UDPConn, stunAddr net.Addr, stunConn io.Reader) {
 var stunServer = flag.String("stun", "stun.l.google.com:19302", "STUN Server to use") //nolint:gochecknoglobals
 
 func main() {
-	isServer := flag.Arg(0) == ""
-
 	flag.Parse()
+
+	isServer := flag.Arg(0) == ""
 
 	// Allocating local UDP socket that will be used both for STUN and
 	// our application data.

--- a/integrity.go
+++ b/integrity.go
@@ -20,8 +20,8 @@ const credentialsSep = ":"
 // credentials. Password, username, and realm must be SASL-prepared.
 func NewLongTermIntegrity(username, realm, password string) MessageIntegrity {
 	k := strings.Join([]string{username, realm, password}, credentialsSep)
-	h := md5.New() //nolint:gosec
-	fmt.Fprint(h, k)
+	h := md5.New()   //nolint:gosec
+	fmt.Fprint(h, k) //nolint:errcheck
 	return MessageIntegrity(h.Sum(nil))
 }
 


### PR DESCRIPTION
Call `flag.Parse()` first to enable normal reading of parameters