### PR TITLE
Remove `stun` scheme from default server flag

### DIFF
--- a/cmd/stun-traversal/main.go
+++ b/cmd/stun-traversal/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pion/stun/v3"
 )
 
-var server = flag.String("server", "stun:stun.voipgate.com:3478", "Stun server address") //nolint:gochecknoglobals
+var server = flag.String("server", "stun.voipgate.com:3478", "Stun server address") //nolint:gochecknoglobals
 
 const (
 	udp           = "udp4"


### PR DESCRIPTION
calling `net.ResolveUDPAddr` with `stun:stun.voipgate.com:3478` results in this error `too many colons in address`.
