### PR TITLE
chore: retract invalid versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/pion/stun
 
 go 1.12
 
+retract [v1.0.0, v1.23.0] // invalid module path
+
 require (
 	github.com/pion/dtls/v2 v2.2.7
 	github.com/pion/logging v0.2.2


### PR DESCRIPTION
This retracts invalid versions so that `go get -u` type commands work smoothly. These versions have their module path in go.mod file as `gortc.io/stun`. 

https://proxy.golang.org/github.com/pion/stun/@v/list