### PR TITLE
Retract new version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/pion/stun
 
 go 1.12
 
-retract [v1.0.0, v1.23.0] // invalid module path
+retract [v1.0.0, v1.23.1] // invalid module path
 
 require (
 	github.com/pion/dtls/v2 v2.2.7


### PR DESCRIPTION
We need to retract the new release too. 

Retracting v1.23.1 ensures that when we publish 1.23.1 go tooling will downgrade correctly to 0.6.1
