### PR TITLE
`Interface{}` can be replaced by `any`

### DIFF
--- a/client.go
+++ b/client.go
@@ -319,7 +319,7 @@ func (t *clientTransaction) handle(e Event) {
 }
 
 var clientTransactionPool = &sync.Pool{ //nolint:gochecknoglobals
-	New: func() interface{} {
+	New: func() any {
 		return &clientTransaction{
 			raw: make([]byte, 1500),
 		}
@@ -562,7 +562,7 @@ func (s *callbackWaitHandler) setCallback(f func(event Event)) {
 }
 
 var callbackWaitHandlerPool = sync.Pool{ //nolint:gochecknoglobals
-	New: func() interface{} {
+	New: func() any {
 		return &callbackWaitHandler{
 			cond: sync.NewCond(new(sync.Mutex)),
 		}
@@ -618,7 +618,7 @@ type buffer struct {
 }
 
 var bufferPool = &sync.Pool{ //nolint:gochecknoglobals
-	New: func() interface{} {
+	New: func() any {
 		return &buffer{buf: make([]byte, 2048)}
 	},
 }

--- a/internal/hmac/pool.go
+++ b/internal/hmac/pool.go
@@ -38,7 +38,7 @@ func (h *hmac) resetTo(key []byte) {
 }
 
 var hmacSHA1Pool = &sync.Pool{ //nolint:gochecknoglobals
-	New: func() interface{} {
+	New: func() any {
 		h := New(sha1.New, make([]byte, sha1.BlockSize))
 
 		return h
@@ -62,7 +62,7 @@ func PutSHA1(h hash.Hash) {
 }
 
 var hmacSHA256Pool = &sync.Pool{ //nolint:gochecknoglobals
-	New: func() interface{} {
+	New: func() any {
 		h := New(sha256.New, make([]byte, sha256.BlockSize))
 
 		return h


### PR DESCRIPTION
`interface{}` can be replaced by `any`

`any` added in go1.18