### PR TITLE
Use pointer types for DialConfig fields

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,8 +37,8 @@ func Dial(network, address string) (*Client, error) {
 
 // DialConfig is used to pass configuration to DialURI().
 type DialConfig struct {
-	DTLSConfig dtls.Config
-	TLSConfig  tls.Config
+	DTLSConfig *dtls.Config
+	TLSConfig  *tls.Config
 
 	Net transport.Net
 }
@@ -76,7 +76,10 @@ func DialURI(uri *URI, cfg *DialConfig) (*Client, error) { //nolint:cyclop
 		}
 
 	case uri.Scheme == SchemeTypeTURNS && uri.Proto == ProtoTypeUDP:
-		dtlsCfg := cfg.DTLSConfig // Copy
+		var dtlsCfg dtls.Config
+		if cfg.DTLSConfig != nil {
+			dtlsCfg = *cfg.DTLSConfig
+		}
 		dtlsCfg.ServerName = uri.Host
 
 		udpAddr, err := net.ResolveUDPAddr("udp", addr)
@@ -94,7 +97,10 @@ func DialURI(uri *URI, cfg *DialConfig) (*Client, error) { //nolint:cyclop
 		}
 
 	case (uri.Scheme == SchemeTypeTURNS || uri.Scheme == SchemeTypeSTUNS) && uri.Proto == ProtoTypeTCP:
-		tlsCfg := cfg.TLSConfig //nolint:govet, copylocks
+		var tlsCfg tls.Config
+		if cfg.TLSConfig != nil {
+			tlsCfg = *cfg.TLSConfig.Clone()
+		}
 		tlsCfg.ServerName = uri.Host
 
 		tcpConn, err := nw.Dial("tcp", addr)


### PR DESCRIPTION
## Summary
- Change `TLSConfig` and `DTLSConfig` fields in `DialConfig` from value types (`tls.Config`, `dtls.Config`) to pointers (`*tls.Config`, `*dtls.Config`)
- Removes the `//nolint:govet, copylocks` suppression that was needed for the value-copy pattern
- `DialURI` handles nil configs by falling back to zero-value defaults, and clones before mutating `ServerName` to avoid side effects

Fixes #235

## Test plan
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean (copylocks warning gone)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go build ./...` compiles all packages and CLI tools