### PR TITLE
Silently ignore attributes after message-integrity

### DIFF
--- a/integrity.go
+++ b/integrity.go
@@ -104,20 +104,17 @@ func (i MessageIntegrity) Check(msg *Message) error {
 	// Adjusting length in header to match m.Raw that was
 	// used when computing HMAC.
 	var (
-		length         = msg.Length
-		afterIntegrity = false
-		sizeReduced    int
+		length      = msg.Length
+		sizeReduced int
 	)
 	for _, a := range msg.Attributes {
-		if afterIntegrity {
-			sizeReduced += nearestPaddedValueLength(int(a.Length))
-			sizeReduced += attributeHeaderSize
-		}
+		sizeReduced += attributeHeaderSize
+		sizeReduced += nearestPaddedValueLength(int(a.Length))
 		if a.Type == AttrMessageIntegrity {
-			afterIntegrity = true
+			break
 		}
 	}
-	msg.Length -= uint32(sizeReduced) //nolint:gosec // G115
+	msg.Length = uint32(sizeReduced) // /nolint:gosec
 	msg.WriteLength()
 	// startOfHMAC should be first byte of integrity attribute.
 	startOfHMAC := messageHeaderSize + msg.Length - (attributeHeaderSize + messageIntegritySize)

--- a/integrity_test.go
+++ b/integrity_test.go
@@ -4,6 +4,7 @@
 package stun
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
@@ -61,6 +62,24 @@ func TestMessageIntegrityBeforeFingerprint(t *testing.T) {
 	Fingerprint.AddTo(m) //nolint:errcheck,gosec
 	i := NewShortTermIntegrity("password")
 	assert.Error(t, i.AddTo(m))
+}
+
+func TestAttributeAfterMessageIntegrity(t *testing.T) {
+	m := new(Message)
+	m.WriteHeader()
+	i := NewShortTermIntegrity("password")
+	assert.NoError(t, i.AddTo(m))
+	assert.NoError(t, NewSoftware("after").AddTo(m))
+	assert.NoError(t, Fingerprint.AddTo(m))
+
+	mDecoded := New()
+	_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
+	assert.NoError(t, err)
+
+	assert.NoError(t, i.Check(mDecoded))
+	assert.NoError(t, Fingerprint.Check(mDecoded))
+	_, found := mDecoded.Attributes.Get(AttrSoftware)
+	assert.False(t, found)
 }
 
 func BenchmarkMessageIntegrity_AddTo(b *testing.B) {

--- a/message.go
+++ b/message.go
@@ -367,7 +367,7 @@ func (m *Message) ReadFrom(r io.Reader) (int64, error) {
 var ErrUnexpectedHeaderEOF = errors.New("unexpected EOF: not enough bytes to read header")
 
 // Decode decodes m.Raw into m.
-func (m *Message) Decode() error {
+func (m *Message) Decode() error { //nolint:cyclop
 	// decoding message header
 	buf := m.Raw
 	if len(buf) < messageHeaderSize {
@@ -399,6 +399,7 @@ func (m *Message) Decode() error {
 		offset = 0
 		b      = buf[messageHeaderSize:fullSize]
 	)
+	hadMessageIntegrity := false
 	for offset < size {
 		// checking that we have enough bytes to read header
 		if len(b) < attributeHeaderSize {
@@ -425,7 +426,17 @@ func (m *Message) Decode() error {
 		offset += aBuffL
 		b = b[aBuffL:]
 
-		m.Attributes = append(m.Attributes, attr)
+		// RFC 5389:
+		// With the exception of the FINGERPRINT attribute,
+		// which appears after MESSAGE-INTEGRITY, agents MUST ignore
+		// all other attributes that follow MESSAGE-INTEGRITY.
+		if !hadMessageIntegrity || (attr.Type == AttrMessageIntegrity) ||
+			(attr.Type == AttrMessageIntegritySHA256) || (attr.Type == AttrFingerprint) {
+			m.Attributes = append(m.Attributes, attr)
+		}
+		if attr.Type == AttrMessageIntegrity || attr.Type == AttrMessageIntegritySHA256 {
+			hadMessageIntegrity = true
+		}
 	}
 
 	return nil


### PR DESCRIPTION
with the exception of fingerprint and the sha256-variant of message-integrity.

See
  https://datatracker.ietf.org/doc/html/rfc5389#section-15.4
and
  https://datatracker.ietf.org/doc/html/rfc8489#section-9