### PR TITLE
Throw an error when parsing message type 0x0000

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -833,10 +833,11 @@ func TestClientPassesMessageOptions(t *testing.T) {
 		assert.NoError(t, connL.Close())
 	}()
 
-	i := NewShortTermIntegrity("password")
+	integrity := NewShortTermIntegrity("password")
 	msg := New()
+	msg.Type = BindingRequest
 	msg.WriteHeader()
-	assert.NoError(t, i.AddTo(msg))
+	assert.NoError(t, integrity.AddTo(msg))
 	assert.NoError(t, NewSoftware("after").AddTo(msg))
 	assert.NoError(t, Fingerprint.AddTo(msg))
 
@@ -845,7 +846,7 @@ func TestClientPassesMessageOptions(t *testing.T) {
 		process: func(m *Message) error {
 			_, found := m.Attributes.Get(AttrSoftware)
 			assert.False(t, found)
-			assert.NoError(t, i.Check(m))
+			assert.NoError(t, integrity.Check(m))
 			assert.NoError(t, Fingerprint.Check(m))
 			processed <- struct{}{}
 

--- a/errorcode_test.go
+++ b/errorcode_test.go
@@ -57,6 +57,7 @@ func TestErrorCodeAttribute_GetFrom(t *testing.T) {
 
 func TestMessage_AddErrorCode(t *testing.T) {
 	m := New()
+	m.Type = BindingError
 	transactionID, err := base64.StdEncoding.DecodeString("jxhBARZwX+rsC6er")
 	assert.NoError(t, err)
 	copy(m.TransactionID[:], transactionID)

--- a/integrity_test.go
+++ b/integrity_test.go
@@ -66,6 +66,7 @@ func TestMessageIntegrityBeforeFingerprint(t *testing.T) {
 
 func TestAttributeAfterMessageIntegrity(t *testing.T) {
 	m := new(Message)
+	m.Type = BindingRequest
 	m.WriteHeader()
 	i := NewShortTermIntegrity("password")
 	assert.NoError(t, i.AddTo(m))
@@ -79,11 +80,12 @@ func TestAttributeAfterMessageIntegrity(t *testing.T) {
 	assert.NoError(t, i.Check(mDecoded))
 	assert.NoError(t, Fingerprint.Check(mDecoded))
 	_, found := mDecoded.Attributes.Get(AttrSoftware)
-	assert.True(t, found)
+	assert.Equal(t, found, !mDecoded.strict)
 }
 
 func TestAttributeAfterMessageIntegrityStrict(t *testing.T) {
 	m := new(Message)
+	m.Type = BindingRequest
 	m.WriteHeader()
 	i := NewShortTermIntegrity("password")
 	assert.NoError(t, i.AddTo(m))
@@ -103,6 +105,7 @@ func TestAttributeAfterMessageIntegrityStrict(t *testing.T) {
 func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 	t.Run("MI256, SOFTWARE, FINGERPRINT", func(t *testing.T) {
 		m := new(Message)
+		m.Type = BindingRequest
 		m.WriteHeader()
 		m.Add(AttrMessageIntegritySHA256, make([]byte, 32))
 		assert.NoError(t, NewSoftware("after").AddTo(m))
@@ -119,6 +122,7 @@ func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 
 	t.Run("MI256, MI, FINGERPRINT", func(t *testing.T) {
 		m := new(Message)
+		m.Type = BindingRequest
 		m.WriteHeader()
 		m.Add(AttrMessageIntegritySHA256, make([]byte, 32))
 		m.Add(AttrMessageIntegrity, make([]byte, 20))
@@ -137,6 +141,7 @@ func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 
 	t.Run("MI, MI256, FINGERPRINT", func(t *testing.T) {
 		m := new(Message)
+		m.Type = BindingRequest
 		m.WriteHeader()
 		m.Add(AttrMessageIntegrity, make([]byte, 20))
 		m.Add(AttrMessageIntegritySHA256, make([]byte, 32))
@@ -155,6 +160,7 @@ func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 
 	t.Run("MI, MI, FINGERPRINT", func(t *testing.T) {
 		m := new(Message)
+		m.Type = BindingRequest
 		m.WriteHeader()
 		m.Add(AttrMessageIntegrity, make([]byte, 20))
 		m.Add(AttrMessageIntegrity, make([]byte, 20))

--- a/message.go
+++ b/message.go
@@ -390,12 +390,22 @@ func (m *Message) ReadFrom(r io.Reader) (int64, error) {
 	}
 	m.Raw = tBuf[:n]
 
-	return int64(n), m.Decode()
+	if err = m.Decode(); err != nil {
+		return int64(n), err
+	}
+	if m.strict && m.Type.Value() == 0 {
+		return int64(n), ErrInvalidType
+	}
+
+	return int64(n), nil
 }
 
 // ErrUnexpectedHeaderEOF means that there were not enough bytes in
 // m.Raw to read header.
 var ErrUnexpectedHeaderEOF = errors.New("unexpected EOF: not enough bytes to read header")
+
+// ErrInvalidType means that the message type is 0 (reserved).
+var ErrInvalidType = errors.New("STUN message type 0 is reserved")
 
 // Decode decodes m.Raw into m.
 func (m *Message) Decode() error { //nolint:cyclop

--- a/message_test.go
+++ b/message_test.go
@@ -890,3 +890,18 @@ func TestMessage_GobDecode(t *testing.T) {
 	}
 	assert.NoError(t, msg.Decode())
 }
+
+func TestMessageReservedType(t *testing.T) {
+	m := New()
+	m.TransactionID = NewTransactionID()
+	m.WriteHeader()
+
+	// Backward-compat behavior.
+	mDecoded := NewWithOptions(WithStrict(false))
+	_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
+	assert.NoError(t, err)
+
+	mDecodedStrict := NewWithOptions(WithStrict(true))
+	_, err = mDecodedStrict.ReadFrom(bytes.NewReader(m.Raw))
+	assert.ErrorIs(t, err, ErrInvalidType)
+}

--- a/textattrs_test.go
+++ b/textattrs_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestSoftware_GetFrom(t *testing.T) {
 	msg := New()
+	msg.Type = BindingRequest
 	val := "Client v0.0.1"
 	msg.Add(AttrSoftware, []byte(val))
 	msg.WriteHeader()
@@ -108,6 +109,7 @@ func TestUsername(t *testing.T) {
 
 func TestRealm_GetFrom(t *testing.T) {
 	msg := New()
+	msg.Type = BindingRequest
 	val := "realm"
 	msg.Add(AttrRealm, []byte(val))
 	msg.WriteHeader()
@@ -137,6 +139,7 @@ func TestRealm_AddTo_Invalid(t *testing.T) {
 
 func TestNonce_GetFrom(t *testing.T) {
 	msg := New()
+	msg.Type = BindingRequest
 	val := "example.org"
 	msg.Add(AttrNonce, []byte(val))
 	msg.WriteHeader()

--- a/xoraddr_test.go
+++ b/xoraddr_test.go
@@ -73,6 +73,7 @@ func TestXORMappedAddress_GetFrom(t *testing.T) {
 
 func TestXORMappedAddress_GetFrom_Invalid(t *testing.T) {
 	msg := New()
+	msg.Type = BindingSuccess
 	transactionID, err := base64.StdEncoding.DecodeString("jxhBARZwX+rsC6er")
 	assert.NoError(t, err)
 	copy(msg.TransactionID[:], transactionID)
@@ -117,6 +118,7 @@ func TestXORMappedAddress_AddTo(t *testing.T) {
 
 func TestXORMappedAddress_AddTo_IPv6(t *testing.T) {
 	msg := New()
+	msg.Type = BindingSuccess
 	transactionID, err := base64.StdEncoding.DecodeString("jxhBARZwX+rsC6er")
 	assert.NoError(t, err)
 	copy(msg.TransactionID[:], transactionID)


### PR DESCRIPTION
which is reserved in RFC 5389:
  https://datatracker.ietf.org/doc/html/rfc5389#section-18.1

(technically this is a breaking change. Doesn't look like pion/ice has a problem with it which is good)
