### PR TITLE
Add an opt-in strict mode and logger

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/pion/dtls/v3"
+	"github.com/pion/logging"
 	"github.com/pion/transport/v4"
 	"github.com/pion/transport/v4/stdnet"
 )
@@ -174,6 +175,25 @@ func WithNoConnClose() ClientOption {
 	}
 }
 
+// WithStrictMode sets strict decode behavior for messages decoded by the client.
+func WithStrictMode(strict bool) ClientOption {
+	return func(c *Client) {
+		c.strict = strict
+	}
+}
+
+// WithLoggerFactory sets logger used by the client and decoded messages.
+func WithLoggerFactory(loggerFactory logging.LoggerFactory) ClientOption {
+	return func(c *Client) {
+		if loggerFactory == nil {
+			c.logger = nil
+
+			return
+		}
+		c.logger = loggerFactory.NewLogger("stun")
+	}
+}
+
 // WithNoRetransmit disables retransmissions and sets RTO to
 // defaultMaxAttempts * defaultRTO which will be effectively time out
 // if not set.
@@ -293,6 +313,8 @@ type Client struct {
 	handler     Handler
 	collector   Collector
 	t           map[transactionID]*clientTransaction
+	logger      logging.LeveledLogger
+	strict      bool
 
 	// mux guards closed and t
 	mux sync.RWMutex
@@ -413,7 +435,13 @@ func (c CloseErr) Error() string {
 
 func (c *Client) readUntilClosed() {
 	defer c.wg.Done()
-	m := new(Message)
+	options := []MessageOption{
+		WithStrict(c.strict),
+	}
+	if c.logger != nil {
+		options = append(options, withMessageLogger(c.logger))
+	}
+	m := NewWithOptions(options...)
 	m.Raw = make([]byte, 1024)
 	for {
 		select {

--- a/client_test.go
+++ b/client_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -824,6 +825,100 @@ func TestNewClient(t *testing.T) {
 		)
 		assert.ErrorIs(t, createErr, startError, "unexpected error returned")
 	})
+}
+
+func TestClientPassesMessageOptions(t *testing.T) {
+	connL, connR := net.Pipe()
+	defer func() {
+		assert.NoError(t, connL.Close())
+	}()
+
+	i := NewShortTermIntegrity("password")
+	msg := New()
+	msg.WriteHeader()
+	assert.NoError(t, i.AddTo(msg))
+	assert.NoError(t, NewSoftware("after").AddTo(msg))
+	assert.NoError(t, Fingerprint.AddTo(msg))
+
+	processed := make(chan struct{}, 1)
+	agent := &manualAgent{
+		process: func(m *Message) error {
+			_, found := m.Attributes.Get(AttrSoftware)
+			assert.False(t, found)
+			assert.NoError(t, i.Check(m))
+			assert.NoError(t, Fingerprint.Check(m))
+			processed <- struct{}{}
+
+			return nil
+		},
+	}
+
+	client, err := NewClient(connR,
+		WithAgent(agent),
+		WithStrictMode(true),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, client.Close())
+	}()
+
+	_, err = connL.Write(msg.Raw)
+	assert.NoError(t, err)
+
+	select {
+	case <-processed:
+	case <-time.After(time.Second):
+		assert.Fail(t, "timed out waiting for decoded message")
+	}
+}
+
+func TestClientWithLoggerFactory(t *testing.T) {
+	connL, connR := net.Pipe()
+	defer func() {
+		assert.NoError(t, connL.Close())
+	}()
+
+	i := NewShortTermIntegrity("password")
+	msg := New()
+	msg.WriteHeader()
+	assert.NoError(t, i.AddTo(msg))
+	assert.NoError(t, NewSoftware("after").AddTo(msg))
+	assert.NoError(t, Fingerprint.AddTo(msg))
+
+	processed := make(chan struct{}, 1)
+	agent := &manualAgent{
+		process: func(m *Message) error {
+			_, found := m.Attributes.Get(AttrSoftware)
+			assert.True(t, found)
+			processed <- struct{}{}
+
+			return nil
+		},
+	}
+
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	loggerFactory.DefaultLogLevel = logging.LogLevelWarn
+	var logOutput bytes.Buffer
+	loggerFactory.Writer = &logOutput
+
+	client, err := NewClient(connR,
+		WithAgent(agent),
+		WithLoggerFactory(loggerFactory),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, client.Close())
+	}()
+
+	_, err = connL.Write(msg.Raw)
+	assert.NoError(t, err)
+
+	select {
+	case <-processed:
+	case <-time.After(time.Second):
+		assert.Fail(t, "timed out waiting for decoded message")
+	}
+	assert.Contains(t, logOutput.String(), "attribute SOFTWARE found after integrity attribute (retained)")
 }
 
 func TestClient_Close(t *testing.T) {

--- a/integrity_test.go
+++ b/integrity_test.go
@@ -79,7 +79,100 @@ func TestAttributeAfterMessageIntegrity(t *testing.T) {
 	assert.NoError(t, i.Check(mDecoded))
 	assert.NoError(t, Fingerprint.Check(mDecoded))
 	_, found := mDecoded.Attributes.Get(AttrSoftware)
+	assert.True(t, found)
+}
+
+func TestAttributeAfterMessageIntegrityStrict(t *testing.T) {
+	m := new(Message)
+	m.WriteHeader()
+	i := NewShortTermIntegrity("password")
+	assert.NoError(t, i.AddTo(m))
+	assert.NoError(t, NewSoftware("after").AddTo(m))
+	assert.NoError(t, Fingerprint.AddTo(m))
+
+	mDecoded := NewWithOptions(WithStrict(true))
+	_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
+	assert.NoError(t, err)
+
+	assert.NoError(t, i.Check(mDecoded))
+	assert.NoError(t, Fingerprint.Check(mDecoded))
+	_, found := mDecoded.Attributes.Get(AttrSoftware)
 	assert.False(t, found)
+}
+
+func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
+	t.Run("MI256, SOFTWARE, FINGERPRINT", func(t *testing.T) {
+		m := new(Message)
+		m.WriteHeader()
+		m.Add(AttrMessageIntegritySHA256, make([]byte, 32))
+		assert.NoError(t, NewSoftware("after").AddTo(m))
+		assert.NoError(t, Fingerprint.AddTo(m))
+
+		mDecoded := NewWithOptions(WithStrict(true))
+		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
+		assert.NoError(t, err)
+
+		_, foundSoftware := mDecoded.Attributes.Get(AttrSoftware)
+		assert.False(t, foundSoftware)
+		assert.NoError(t, Fingerprint.Check(mDecoded))
+	})
+
+	t.Run("MI256, MI, FINGERPRINT", func(t *testing.T) {
+		m := new(Message)
+		m.WriteHeader()
+		m.Add(AttrMessageIntegritySHA256, make([]byte, 32))
+		m.Add(AttrMessageIntegrity, make([]byte, 20))
+		assert.NoError(t, Fingerprint.AddTo(m))
+
+		mDecoded := NewWithOptions(WithStrict(true))
+		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
+		assert.NoError(t, err)
+
+		_, foundMI := mDecoded.Attributes.Get(AttrMessageIntegrity)
+		assert.False(t, foundMI)
+		_, foundMI256 := mDecoded.Attributes.Get(AttrMessageIntegritySHA256)
+		assert.True(t, foundMI256)
+		assert.NoError(t, Fingerprint.Check(mDecoded))
+	})
+
+	t.Run("MI, MI256, FINGERPRINT", func(t *testing.T) {
+		m := new(Message)
+		m.WriteHeader()
+		m.Add(AttrMessageIntegrity, make([]byte, 20))
+		m.Add(AttrMessageIntegritySHA256, make([]byte, 32))
+		assert.NoError(t, Fingerprint.AddTo(m))
+
+		mDecoded := NewWithOptions(WithStrict(true))
+		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
+		assert.NoError(t, err)
+
+		_, foundMI := mDecoded.Attributes.Get(AttrMessageIntegrity)
+		assert.True(t, foundMI)
+		_, foundMI256 := mDecoded.Attributes.Get(AttrMessageIntegritySHA256)
+		assert.True(t, foundMI256)
+		assert.NoError(t, Fingerprint.Check(mDecoded))
+	})
+
+	t.Run("MI, MI, FINGERPRINT", func(t *testing.T) {
+		m := new(Message)
+		m.WriteHeader()
+		m.Add(AttrMessageIntegrity, make([]byte, 20))
+		m.Add(AttrMessageIntegrity, make([]byte, 20))
+		assert.NoError(t, Fingerprint.AddTo(m))
+
+		mDecoded := NewWithOptions(WithStrict(true))
+		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
+		assert.NoError(t, err)
+
+		count := 0
+		for _, a := range mDecoded.Attributes {
+			if a.Type == AttrMessageIntegrity {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count)
+		assert.NoError(t, Fingerprint.Check(mDecoded))
+	})
 }
 
 func BenchmarkMessageIntegrity_AddTo(b *testing.B) {

--- a/message.go
+++ b/message.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/pion/logging"
 )
 
 const (
@@ -44,6 +46,9 @@ func IsMessage(b []byte) bool {
 	return len(b) >= messageHeaderSize && bin.Uint32(b[4:8]) == magicCookie
 }
 
+// MessageOption is a function that sets a Message option.
+type MessageOption func(*Message)
+
 // New returns *Message with pre-allocated Raw.
 func New() *Message {
 	const defaultRawCapacity = 120
@@ -51,6 +56,16 @@ func New() *Message {
 	return &Message{
 		Raw: make([]byte, messageHeaderSize, defaultRawCapacity),
 	}
+}
+
+// NewWithOptions returns *Message with pre-allocated Raw, applying the provided options.
+func NewWithOptions(options ...MessageOption) *Message {
+	m := New()
+	for _, option := range options {
+		option(m)
+	}
+
+	return m
 }
 
 // ErrDecodeToNil occurs on Decode(data, nil) call.
@@ -78,6 +93,22 @@ type Message struct {
 	TransactionID [TransactionIDSize]byte
 	Attributes    Attributes
 	Raw           []byte
+	logger        logging.LeveledLogger
+	strict        bool
+}
+
+// withMessageLogger sets the logger for the Message.
+func withMessageLogger(logger logging.LeveledLogger) MessageOption {
+	return func(m *Message) {
+		m.logger = logger
+	}
+}
+
+// WithStrict enables stricter RFC 5389 and RFC 8489 enforcement.
+func WithStrict(strict bool) MessageOption {
+	return func(m *Message) {
+		m.strict = strict
+	}
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
@@ -399,7 +430,8 @@ func (m *Message) Decode() error { //nolint:cyclop
 		offset = 0
 		b      = buf[messageHeaderSize:fullSize]
 	)
-	hadMessageIntegrity := false
+	seenMI := false
+	seenMI256 := false
 	for offset < size {
 		// checking that we have enough bytes to read header
 		if len(b) < attributeHeaderSize {
@@ -426,16 +458,34 @@ func (m *Message) Decode() error { //nolint:cyclop
 		offset += aBuffL
 		b = b[aBuffL:]
 
-		// RFC 5389:
-		// With the exception of the FINGERPRINT attribute,
-		// which appears after MESSAGE-INTEGRITY, agents MUST ignore
-		// all other attributes that follow MESSAGE-INTEGRITY.
-		if !hadMessageIntegrity || (attr.Type == AttrMessageIntegrity) ||
-			(attr.Type == AttrMessageIntegritySHA256) || (attr.Type == AttrFingerprint) {
-			m.Attributes = append(m.Attributes, attr)
+		// RFC 8489:
+		// - after MESSAGE-INTEGRITY, only MESSAGE-INTEGRITY-SHA256 and
+		//   FINGERPRINT may follow.
+		// - after MESSAGE-INTEGRITY-SHA256, if MESSAGE-INTEGRITY was absent,
+		//   only FINGERPRINT may follow.
+		isMI := attr.Type == AttrMessageIntegrity
+		isMI256 := attr.Type == AttrMessageIntegritySHA256
+		isFingerprint := attr.Type == AttrFingerprint
+		afterMI := seenMI && !isMI256 && !isFingerprint
+		afterMI256Only := !seenMI && seenMI256 && !isFingerprint
+		afterIntegrity := afterMI || afterMI256Only
+
+		if afterIntegrity && (m.logger != nil) {
+			action := "retained"
+			if m.strict {
+				action = "dropped"
+			}
+			m.logger.Warnf("attribute %s found after integrity attribute (%s)", attr.Type.String(), action)
 		}
-		if attr.Type == AttrMessageIntegrity || attr.Type == AttrMessageIntegritySHA256 {
-			hadMessageIntegrity = true
+		if m.strict && afterIntegrity {
+			continue
+		}
+		m.Attributes = append(m.Attributes, attr)
+		if isMI {
+			seenMI = true
+		}
+		if isMI256 {
+			seenMI256 = true
 		}
 	}
 


### PR DESCRIPTION

#### Description

Introduce a new opt-in strict mode (we should flip it to the default in the far future). in the strict mode we're going to enforce the specs more.
Also adds a logger so we can print spec errors outside of the strict mode.

#### Reference issue
related to https://github.com/pion/ice/issues/915#issuecomment-4338214886 and https://github.com/pion/stun/pull/273