### PR TITLE
Fix panic on short XOR-MAPPED-ADDRESS value

### DIFF
--- a/xoraddr.go
+++ b/xoraddr.go
@@ -91,6 +91,9 @@ func (a *XORMappedAddress) GetFromAs(msg *Message, attr AttrType) error {
 	if err != nil {
 		return err
 	}
+	if len(value) <= 4 {
+		return io.ErrUnexpectedEOF
+	}
 	family := bin.Uint16(value[0:2])
 	if family != familyIPv6 && family != familyIPv4 {
 		return newDecodeErr("xor-mapped address", "family",
@@ -111,9 +114,6 @@ func (a *XORMappedAddress) GetFromAs(msg *Message, attr AttrType) error {
 		}
 	}
 
-	if len(value) <= 4 {
-		return io.ErrUnexpectedEOF
-	}
 	if err := CheckOverflow(attr, len(value[4:]), len(a.IP)); err != nil {
 		return err
 	}

--- a/xoraddr_test.go
+++ b/xoraddr_test.go
@@ -69,6 +69,22 @@ func TestXORMappedAddress_GetFrom(t *testing.T) {
 		addr := new(XORMappedAddress)
 		assert.True(t, IsAttrSizeOverflow(addr.GetFrom(m)), "GetFrom should return *AttrOverflowErr")
 	})
+	t.Run("ShortValue", func(t *testing.T) {
+		// A zero-length XOR-MAPPED-ADDRESS value at the end of a tightly
+		// allocated buffer must not panic when reading the address family.
+		raw := []byte{
+			0x01, 0x01, 0x00, 0x04, // type=Binding success, length=4
+			0x21, 0x12, 0xA4, 0x42, // magic cookie
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // transaction ID
+			0x00, 0x20, 0x00, 0x00, // XOR-MAPPED-ADDRESS, length=0
+		}
+		// Cap == len so the decoded value slice has no spare capacity.
+		m := New()
+		m.Raw = raw[:len(raw):len(raw)]
+		assert.NoError(t, m.Decode())
+		addr := new(XORMappedAddress)
+		assert.ErrorIs(t, addr.GetFrom(m), io.ErrUnexpectedEOF, "short value should return io.ErrUnexpectedEOF, not panic")
+	})
 }
 
 func TestXORMappedAddress_GetFrom_Invalid(t *testing.T) {


### PR DESCRIPTION
XORMappedAddress.GetFromAs read value[0:2] to decode the address family before validating the attribute value length. A malformed STUN message carrying an XOR-MAPPED-ADDRESS attribute with a 0-length value at the end of a tightly allocated buffer triggered a slice-bounds runtime panic, since the value slice had no spare capacity to re-slice into.

Move the length check ahead of the first read so a short value returns io.ErrUnexpectedEOF instead of panicking. This is remotely triggerable on normal STUN/ICE Binding-response parsing paths.

Reported-By: karolina.gorna@ledger.com
