### PR TITLE
Fix UnknownAttributes encoding to match RFC 5389

### DIFF
--- a/uattrs.go
+++ b/uattrs.go
@@ -30,14 +30,14 @@ func (a UnknownAttributes) String() string {
 }
 
 // type size is 16 bit.
-const attrTypeSize = 4
+const attrTypeSize = 2
 
 // AddTo adds UNKNOWN-ATTRIBUTES attribute to message.
 func (a UnknownAttributes) AddTo(m *Message) error {
 	v := make([]byte, 0, attrTypeSize*20) // 20 should be enough
 	// If len(a.Types) > 20, there will be allocations.
 	for i, t := range a {
-		v = append(v, 0, 0, 0, 0) // 4 times by 0 (16 bits)
+		v = append(v, 0, 0) // 2 times by 0 (16 bits)
 		first := attrTypeSize * i
 		last := first + attrTypeSize
 		bin.PutUint16(v[first:last], t.Value())

--- a/uattrs_test.go
+++ b/uattrs_test.go
@@ -31,6 +31,22 @@ func TestUnknownAttributes(t *testing.T) {
 	})
 }
 
+func TestUnknownAttributesEncoding(t *testing.T) {
+	msg := new(Message)
+	attr := &UnknownAttributes{
+		AttrDontFragment,
+		AttrChannelNumber,
+	}
+	assert.NoError(t, attr.AddTo(msg))
+	assert.Equal(t, messageHeaderSize+attributeHeaderSize+4, len(msg.Raw))
+
+	encodedAttr := msg.Raw[messageHeaderSize:]
+	assert.Equal(t, AttrUnknownAttributes.Value(), bin.Uint16(encodedAttr[0:2]))
+	assert.Equal(t, uint16(4), bin.Uint16(encodedAttr[2:4]))
+	assert.Equal(t, AttrDontFragment.Value(), bin.Uint16(encodedAttr[4:6]))
+	assert.Equal(t, AttrChannelNumber.Value(), bin.Uint16(encodedAttr[6:8]))
+}
+
 func BenchmarkUnknownAttributes(b *testing.B) {
 	msg := new(Message)
 	attr := UnknownAttributes{


### PR DESCRIPTION
Pion uses 4 bytes per attribute type instead of 2 as specified in RFC 5389. On send side it is not so bad, other STUN peer will see extra zero attributes, so most likely it will be able to deal with this. In opposite direction there is a data loss, half of received attributes is silently discarded when pion decodes received packet.
