### PR TITLE
Ignore ERROR-CODE reserved bits when decoding class

### DIFF
--- a/errorcode.go
+++ b/errorcode.go
@@ -64,7 +64,7 @@ func (c *ErrorCodeAttribute) GetFrom(m *Message) error {
 		return io.ErrUnexpectedEOF
 	}
 	var (
-		class  = uint16(value[errorCodeClassByte])
+		class  = uint16(value[errorCodeClassByte] & 0x7)
 		number = uint16(value[errorCodeNumberByte])
 		code   = int(class*errorCodeModulo + number)
 	)

--- a/errorcode_test.go
+++ b/errorcode_test.go
@@ -109,3 +109,15 @@ func TestTurnError(t *testing.T) {
 	assert.Equal(t, expected, te.Error())
 	assert.Equal(t, expected, te.String())
 }
+
+func TestErrorCodeAttribute_ReservedBitsIgnored(t *testing.T) {
+	// RFC 5389 §15.6 / RFC 8489 §14.8: the 5 bits above Class are Reserved and
+	// receivers MUST ignore them. Class is only the low 3 bits of the byte.
+	m := New()
+	m.WriteHeader()
+	// 0xE4 has reserved bits set; low 3 bits = 4 (class 4), number 20 => code 420.
+	m.Add(AttrErrorCode, []byte{0x00, 0x00, 0xE4, 20})
+	var c ErrorCodeAttribute
+	assert.NoError(t, c.GetFrom(m))
+	assert.Equal(t, ErrorCode(420), c.Code, "reserved bits not ignored")
+}


### PR DESCRIPTION
The ERROR-CODE value's third byte holds a 3-bit Class in its low bits; the upper 5 bits are Reserved. RFC 5389 §15.6 (and RFC 8489 §14.8) say the Reserved bits SHOULD be 0 and **receivers MUST ignore them**.

`GetFrom` read the entire byte as Class, so an ERROR-CODE arriving with reserved bits set decodes to a wrong code — e.g. class byte `0xE4` (low bits = 4) + number 20 should be `420` but decodes to `22820` — and a value the decoder accepts then fails `AddTo` (`class > errorCodeClassMax`), so the library can't re-emit what it just parsed. Masking the class with `0x7` fixes both. Number is genuinely 8 bits, so only the class byte needs masking. Added a test; full suite stays green.
