### PR TITLE
Drop attributes after M-I by default

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -890,7 +890,7 @@ func TestClientWithLoggerFactory(t *testing.T) {
 	agent := &manualAgent{
 		process: func(m *Message) error {
 			_, found := m.Attributes.Get(AttrSoftware)
-			assert.True(t, found)
+			assert.False(t, found)
 			processed <- struct{}{}
 
 			return nil
@@ -919,7 +919,7 @@ func TestClientWithLoggerFactory(t *testing.T) {
 	case <-time.After(time.Second):
 		assert.Fail(t, "timed out waiting for decoded message")
 	}
-	assert.Contains(t, logOutput.String(), "attribute SOFTWARE found after integrity attribute (retained)")
+	assert.Contains(t, logOutput.String(), "attribute SOFTWARE found after integrity attribute (dropped)")
 }
 
 func TestClient_Close(t *testing.T) {

--- a/integrity_test.go
+++ b/integrity_test.go
@@ -80,29 +80,10 @@ func TestAttributeAfterMessageIntegrity(t *testing.T) {
 	assert.NoError(t, i.Check(mDecoded))
 	assert.NoError(t, Fingerprint.Check(mDecoded))
 	_, found := mDecoded.Attributes.Get(AttrSoftware)
-	assert.Equal(t, found, !mDecoded.strict)
-}
-
-func TestAttributeAfterMessageIntegrityStrict(t *testing.T) {
-	m := new(Message)
-	m.Type = BindingRequest
-	m.WriteHeader()
-	i := NewShortTermIntegrity("password")
-	assert.NoError(t, i.AddTo(m))
-	assert.NoError(t, NewSoftware("after").AddTo(m))
-	assert.NoError(t, Fingerprint.AddTo(m))
-
-	mDecoded := NewWithOptions(WithStrict(true))
-	_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
-	assert.NoError(t, err)
-
-	assert.NoError(t, i.Check(mDecoded))
-	assert.NoError(t, Fingerprint.Check(mDecoded))
-	_, found := mDecoded.Attributes.Get(AttrSoftware)
 	assert.False(t, found)
 }
 
-func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
+func TestAttributeOrderingAfterMessageIntegritySHA256(t *testing.T) {
 	t.Run("MI256, SOFTWARE, FINGERPRINT", func(t *testing.T) {
 		m := new(Message)
 		m.Type = BindingRequest
@@ -111,7 +92,7 @@ func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 		assert.NoError(t, NewSoftware("after").AddTo(m))
 		assert.NoError(t, Fingerprint.AddTo(m))
 
-		mDecoded := NewWithOptions(WithStrict(true))
+		mDecoded := New()
 		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
 		assert.NoError(t, err)
 
@@ -128,7 +109,7 @@ func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 		m.Add(AttrMessageIntegrity, make([]byte, 20))
 		assert.NoError(t, Fingerprint.AddTo(m))
 
-		mDecoded := NewWithOptions(WithStrict(true))
+		mDecoded := New()
 		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
 		assert.NoError(t, err)
 
@@ -147,7 +128,7 @@ func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 		m.Add(AttrMessageIntegritySHA256, make([]byte, 32))
 		assert.NoError(t, Fingerprint.AddTo(m))
 
-		mDecoded := NewWithOptions(WithStrict(true))
+		mDecoded := New()
 		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
 		assert.NoError(t, err)
 
@@ -166,7 +147,7 @@ func TestAttributeOrderingAfterMessageIntegritySHA256Strict(t *testing.T) {
 		m.Add(AttrMessageIntegrity, make([]byte, 20))
 		assert.NoError(t, Fingerprint.AddTo(m))
 
-		mDecoded := NewWithOptions(WithStrict(true))
+		mDecoded := New()
 		_, err := mDecoded.ReadFrom(bytes.NewReader(m.Raw))
 		assert.NoError(t, err)
 

--- a/message.go
+++ b/message.go
@@ -480,14 +480,11 @@ func (m *Message) Decode() error { //nolint:cyclop
 		afterMI256Only := !seenMI && seenMI256 && !isFingerprint
 		afterIntegrity := afterMI || afterMI256Only
 
-		if afterIntegrity && (m.logger != nil) {
-			action := "retained"
-			if m.strict {
-				action = "dropped"
+		if afterIntegrity {
+			if m.logger != nil {
+				m.logger.Warnf("attribute %s found after integrity attribute (dropped)", attr.Type.String())
 			}
-			m.logger.Warnf("attribute %s found after integrity attribute (%s)", attr.Type.String(), action)
-		}
-		if m.strict && afterIntegrity {
+
 			continue
 		}
 		m.Attributes = append(m.Attributes, attr)


### PR DESCRIPTION
no longer gated on strict mode

Note: requires a breaking change so should ride along with #284 