### PR TITLE
Fix client read loop spinning and stream message reading

### DIFF
--- a/client.go
+++ b/client.go
@@ -442,7 +442,14 @@ func (c *Client) readUntilClosed() {
 		options = append(options, withMessageLogger(c.logger))
 	}
 	msg := NewWithOptions(options...)
-	msg.Raw = make([]byte, 1024)
+	if isStreamConnection(c.c) {
+		c.readUntilClosedStream(msg)
+
+		return
+	}
+	// Datagram connections deliver one message per read, so the buffer
+	// must fit the largest possible STUN message to avoid truncation.
+	msg.Raw = make([]byte, maxMessageSize)
 	for {
 		select {
 		case <-c.close:
@@ -456,14 +463,103 @@ func (c *Client) readUntilClosed() {
 			// Exiting the read loop avoids busy-spinning on a permanently
 			// failing connection; pending transactions will time out via
 			// the collector.
-			if c.logger != nil {
-				c.logger.Warnf("read loop stopped due to error: %v", err)
-			}
+			c.warnReadLoop(err)
 
 			return
 		}
 		if pErr := c.a.Process(msg); errors.Is(pErr, ErrAgentClosed) {
 			return
+		}
+	}
+}
+
+// warnReadLoop logs a read loop termination if a logger is configured.
+func (c *Client) warnReadLoop(err error) {
+	if c.logger != nil {
+		c.logger.Warnf("read loop stopped due to error: %v", err)
+	}
+}
+
+// isStreamConnection reports whether conn delivers a byte stream (TCP,
+// TLS) instead of datagrams (UDP, DTLS). Connections that expose no local
+// address are treated as datagrams to preserve the previous behavior.
+func isStreamConnection(conn Connection) bool {
+	la, ok := conn.(interface{ LocalAddr() net.Addr })
+	if !ok {
+		return false
+	}
+	addr := la.LocalAddr()
+	if addr == nil {
+		return false
+	}
+
+	switch addr.Network() {
+	case "udp", "udp4", "udp6":
+		return false
+	default:
+		return true
+	}
+}
+
+// readUntilClosedStream reads and processes complete STUN messages from a
+// stream connection, reassembling fragmented messages and splitting
+// messages coalesced into a single read.
+func (c *Client) readUntilClosedStream(msg *Message) {
+	buf := make([]byte, 0, 1500)
+	scratch := make([]byte, 1500)
+	for {
+		select {
+		case <-c.close:
+			return
+		default:
+		}
+		if err := readFullMessage(c.c, msg, &buf, scratch); err != nil {
+			c.warnReadLoop(err)
+
+			return
+		}
+		if err := msg.Decode(); err != nil {
+			c.warnReadLoop(err)
+
+			return
+		}
+		if msg.strict && msg.Type.Value() == 0 {
+			c.warnReadLoop(ErrInvalidType)
+
+			return
+		}
+		if pErr := c.a.Process(msg); errors.Is(pErr, ErrAgentClosed) {
+			return
+		}
+	}
+}
+
+// readFullMessage reads from r until buf contains a complete STUN message,
+// extracts it into msg.Raw and leaves any trailing bytes in buf for the
+// next call.
+func readFullMessage(r io.Reader, msg *Message, buf *[]byte, scratch []byte) error {
+	for {
+		if size, ok := fullSTUNMessageSize(*buf); ok {
+			msg.Raw = append(msg.Raw[:0], (*buf)[:size]...)
+			copy(*buf, (*buf)[size:])
+			*buf = (*buf)[:len(*buf)-size]
+
+			return nil
+		}
+		n, err := r.Read(scratch)
+		if n > 0 {
+			*buf = append(*buf, scratch[:n]...)
+		}
+		if err != nil {
+			// The stream ended: deliver a final complete message if one
+			// is buffered, otherwise report the error.
+			if size, ok := fullSTUNMessageSize(*buf); ok {
+				msg.Raw = append(msg.Raw[:0], (*buf)[:size]...)
+
+				return nil
+			}
+
+			return err
 		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -441,19 +441,29 @@ func (c *Client) readUntilClosed() {
 	if c.logger != nil {
 		options = append(options, withMessageLogger(c.logger))
 	}
-	m := NewWithOptions(options...)
-	m.Raw = make([]byte, 1024)
+	msg := NewWithOptions(options...)
+	msg.Raw = make([]byte, 1024)
 	for {
 		select {
 		case <-c.close:
 			return
 		default:
 		}
-		_, err := m.ReadFrom(c.c)
-		if err == nil {
-			if pErr := c.a.Process(m); errors.Is(pErr, ErrAgentClosed) {
-				return
+		_, err := msg.ReadFrom(c.c)
+		if err != nil {
+			// The connection is unusable after a read error: the peer
+			// may have closed it, or the stream may be out of sync.
+			// Exiting the read loop avoids busy-spinning on a permanently
+			// failing connection; pending transactions will time out via
+			// the collector.
+			if c.logger != nil {
+				c.logger.Warnf("read loop stopped due to error: %v", err)
 			}
+
+			return
+		}
+		if pErr := c.a.Process(msg); errors.Is(pErr, ErrAgentClosed) {
+			return
 		}
 	}
 }

--- a/client_read_loop_test.go
+++ b/client_read_loop_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package stun
+
+import (
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+// countingReadConn counts Read calls and always fails with io.EOF,
+// simulating a peer that closed the connection.
+type countingReadConn struct {
+	reads atomic.Int64
+}
+
+func (c *countingReadConn) Read([]byte) (int, error) {
+	c.reads.Add(1)
+
+	return 0, io.EOF
+}
+
+func (c *countingReadConn) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (c *countingReadConn) Close() error {
+	return nil
+}
+
+// TestReadLoopExitsOnEOF verifies that the client read loop exits after a
+// permanent read error instead of busy-spinning on a failing connection.
+//
+// Regression test: previously the read loop ignored all read errors, so a
+// closed connection caused the goroutine to spin at 100% CPU calling Read
+// millions of times until the client was closed.
+func TestReadLoopExitsOnEOF(t *testing.T) {
+	for _, loggerFactory := range []logging.LoggerFactory{nil, logging.NewDefaultLoggerFactory()} {
+		conn := &countingReadConn{}
+		client, err := NewClient(conn, WithLoggerFactory(loggerFactory))
+		assert.NoError(t, err)
+
+		// Give the read loop time to consume the EOF.
+		time.Sleep(100 * time.Millisecond)
+		first := conn.reads.Load()
+
+		// After the permanent read error the loop must have exited, so the
+		// number of Read calls must not keep growing.
+		time.Sleep(100 * time.Millisecond)
+		second := conn.reads.Load()
+
+		assert.NoError(t, client.Close())
+		t.Logf("Read calls (logger=%v): first window=%d, second window=%d",
+			loggerFactory != nil, first, second-first)
+		assert.LessOrEqual(t, second, first+1,
+			"read loop busy-spins after permanent read error (Read called %d more times)",
+			second-first)
+	}
+}

--- a/client_read_loop_timeout_test.go
+++ b/client_read_loop_timeout_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package stun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReadLoopExitTimesOutTransactions verifies that after the read loop
+// exits due to a connection error, in-flight transactions are still
+// terminated by the timeout collector (the client does not go silent).
+func TestReadLoopExitTimesOutTransactions(t *testing.T) {
+	conn := &countingReadConn{}
+	client, err := NewClient(conn,
+		WithRTO(time.Millisecond*20),
+		WithTimeoutRate(time.Millisecond*5),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, client.Close())
+	}()
+
+	m := MustBuild(TransactionID, BindingRequest)
+	m.Encode()
+	done := make(chan Event, 1)
+	assert.NoError(t, client.Start(m, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		assert.ErrorIs(t, e.Error, ErrTransactionTimeOut,
+			"transaction should time out after read loop exits")
+	case <-time.After(time.Second):
+		assert.FailNow(t, "transaction never timed out after connection failure")
+	}
+
+	// Read loop must have exited (one Read call consumed the EOF).
+	assert.Equal(t, int64(1), conn.reads.Load())
+}

--- a/client_stream_test.go
+++ b/client_stream_test.go
@@ -1,0 +1,391 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package stun
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeResponseWithData builds an encoded Binding success response carrying
+// a DATA attribute of dataLen bytes, so the whole message exceeds the
+// client's 1024-byte read buffer.
+func makeResponseWithData(t *testing.T, dataLen int) (*Message, []byte) {
+	t.Helper()
+	m := MustBuild(TransactionID, BindingSuccess)
+	m.Add(AttrData, make([]byte, dataLen))
+
+	return m, append([]byte{}, m.Raw...)
+}
+
+// startResponseServer accepts a single TCP connection, reads requestBytes
+// (so client transactions are registered before the response arrives) and
+// then writes the response, keeping the connection open briefly before
+// closing it.
+func startResponseServer(t *testing.T, requestBytes int, write func(net.Conn)) net.Addr {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0") //nolint:noctx
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, ln.Close())
+	})
+	go func() {
+		conn, aErr := ln.Accept()
+		if aErr != nil {
+			return
+		}
+		if _, rErr := io.ReadFull(conn, make([]byte, requestBytes)); rErr != nil {
+			return
+		}
+		write(conn)
+		time.Sleep(100 * time.Millisecond)
+		_ = conn.Close()
+	}()
+
+	return ln.Addr()
+}
+
+func newTCPClient(t *testing.T, addr net.Addr) *Client {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr.String()) //nolint:noctx
+	assert.NoError(t, err)
+	client, err := NewClient(conn)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	return client
+}
+
+// TestClientReadLargeMessageStream verifies that a STUN message larger than
+// the 1024-byte read buffer is delivered intact over a TCP connection.
+func TestClientReadLargeMessageStream(t *testing.T) {
+	resp, raw := makeResponseWithData(t, 2000)
+	addr := startResponseServer(t, messageHeaderSize, func(conn net.Conn) {
+		_, _ = conn.Write(raw)
+	})
+	client := newTCPClient(t, addr)
+
+	done := make(chan Event, 1)
+	req := MustBuild(NewTransactionIDSetter(resp.TransactionID), BindingRequest)
+	assert.NoError(t, client.Start(req, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		require.NoError(t, e.Error)
+		require.NotNil(t, e.Message)
+		data, err := e.Message.Get(AttrData)
+		require.NoError(t, err)
+		assert.Len(t, data, 2000, "large message must not be truncated")
+	case <-time.After(time.Second):
+		assert.FailNow(t, "large STUN message over TCP was never delivered")
+	}
+}
+
+// TestClientReadFragmentedMessageStream verifies that a STUN message split
+// across multiple TCP reads is reassembled instead of desynchronizing the
+// stream.
+func TestClientReadFragmentedMessageStream(t *testing.T) {
+	resp, raw := makeResponseWithData(t, 2000)
+	addr := startResponseServer(t, messageHeaderSize, func(conn net.Conn) {
+		// Send the first half, wait so the client reads a partial message,
+		// then send the rest.
+		_, _ = conn.Write(raw[:len(raw)/2])
+		time.Sleep(50 * time.Millisecond)
+		_, _ = conn.Write(raw[len(raw)/2:])
+	})
+	client := newTCPClient(t, addr)
+
+	done := make(chan Event, 1)
+	req := MustBuild(NewTransactionIDSetter(resp.TransactionID), BindingRequest)
+	assert.NoError(t, client.Start(req, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		require.NoError(t, e.Error)
+		require.NotNil(t, e.Message)
+		data, err := e.Message.Get(AttrData)
+		require.NoError(t, err)
+		assert.Len(t, data, 2000, "fragmented message must be reassembled intact")
+	case <-time.After(time.Second):
+		assert.FailNow(t, "fragmented STUN message over TCP was never delivered")
+	}
+}
+
+// TestClientReadCoalescedMessagesStream verifies that two STUN messages
+// arriving in a single TCP read are both delivered to their transactions.
+func TestClientReadCoalescedMessagesStream(t *testing.T) {
+	resp1, raw1 := makeResponseWithData(t, 100)
+	resp2, raw2 := makeResponseWithData(t, 100)
+	addr := startResponseServer(t, 2*messageHeaderSize, func(conn net.Conn) {
+		_, _ = conn.Write(append(raw1, raw2...))
+	})
+	client := newTCPClient(t, addr)
+
+	// The read loop reuses the Message buffer, so each callback must copy
+	// the data it needs before returning.
+	type result struct {
+		err error
+		raw []byte
+	}
+	done := make(chan result, 2)
+	req1 := MustBuild(NewTransactionIDSetter(resp1.TransactionID), BindingRequest)
+	req2 := MustBuild(NewTransactionIDSetter(resp2.TransactionID), BindingRequest)
+	handler := func(e Event) {
+		var raw []byte
+		if e.Message != nil {
+			raw = append([]byte{}, e.Message.Raw...)
+		}
+		done <- result{err: e.Error, raw: raw}
+	}
+	assert.NoError(t, client.Start(req1, handler))
+	assert.NoError(t, client.Start(req2, handler))
+
+	for range 2 {
+		select {
+		case r := <-done:
+			require.NoError(t, r.err)
+			m := &Message{}
+			require.NoError(t, Decode(r.raw, m))
+			_, err := m.Get(AttrData)
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			assert.FailNow(t, "coalesced STUN messages over TCP were not both delivered")
+		}
+	}
+}
+
+// TestClientReadLargeMessageDatagram verifies that a large STUN message on a
+// datagram-style connection is not truncated by the read buffer.
+func TestClientReadLargeMessageDatagram(t *testing.T) {
+	resp, raw := makeResponseWithData(t, 2000)
+	server, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+	})
+	go func() {
+		buf := make([]byte, 1500)
+		n, addr, rErr := server.ReadFrom(buf)
+		if rErr != nil || n <= 0 {
+			return
+		}
+		_, _ = server.WriteTo(raw, addr)
+	}()
+	conn, err := net.Dial("udp", server.LocalAddr().String()) //nolint:noctx
+	require.NoError(t, err)
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	done := make(chan Event, 1)
+	req := MustBuild(NewTransactionIDSetter(resp.TransactionID), BindingRequest)
+	require.NoError(t, client.Start(req, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		require.NoError(t, e.Error)
+		require.NotNil(t, e.Message)
+		data, err := e.Message.Get(AttrData)
+		require.NoError(t, err)
+		assert.Len(t, data, 2000, "datagram message must not be truncated")
+	case <-time.After(time.Second):
+		assert.FailNow(t, "large STUN message on datagram connection was never delivered")
+	}
+}
+
+// TestClientReadStrictTypeZeroStream verifies that a stream message with a
+// reserved message type 0 is rejected in strict mode and the in-flight
+// transaction times out.
+func TestClientReadStrictTypeZeroStream(t *testing.T) {
+	// A 20-byte message with type 0 (reserved), a valid magic cookie and
+	// zero attributes.
+	raw := make([]byte, messageHeaderSize)
+	binary.BigEndian.PutUint16(raw[0:2], 0)
+	binary.BigEndian.PutUint32(raw[4:8], magicCookie)
+	addr := startResponseServer(t, messageHeaderSize, func(conn net.Conn) {
+		_, _ = conn.Write(raw)
+	})
+	conn, err := net.Dial("tcp", addr.String()) //nolint:noctx
+	require.NoError(t, err)
+	client, err := NewClient(conn,
+		WithStrictMode(true),
+		WithLoggerFactory(logging.NewDefaultLoggerFactory()),
+		WithRTO(100*time.Millisecond),
+	)
+	require.NoError(t, err)
+	WithNoRetransmit(client)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	done := make(chan Event, 1)
+	req := MustBuild(TransactionID, BindingRequest)
+	require.NoError(t, client.Start(req, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		require.ErrorIs(t, e.Error, ErrTransactionTimeOut,
+			"reserved message type must be rejected, leaving the transaction to time out")
+	case <-time.After(time.Second):
+		assert.FailNow(t, "transaction was not terminated after reserved type message")
+	}
+}
+
+// streamReaderConnection is a Connection whose LocalAddr reports a TCP
+// address, so the client treats it as a stream. Each Read call returns the
+// next chunk followed by the configured error.
+type streamReaderConnection struct {
+	chunks [][]byte
+	readAt int
+	err    error
+}
+
+func (c *streamReaderConnection) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1}
+}
+
+func (c *streamReaderConnection) Read(b []byte) (int, error) {
+	if c.readAt < len(c.chunks) {
+		n := copy(b, c.chunks[c.readAt])
+		c.readAt++
+
+		return n, c.err
+	}
+
+	return 0, io.EOF
+}
+
+func (c *streamReaderConnection) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (c *streamReaderConnection) Close() error {
+	return nil
+}
+
+// TestClientReadFinalMessageOnEOFStream verifies that a complete message
+// delivered together with io.EOF is still handed to the transaction.
+func TestClientReadFinalMessageOnEOFStream(t *testing.T) {
+	resp, raw := makeResponseWithData(t, 100)
+	conn := &streamReaderConnection{
+		chunks: [][]byte{raw},
+		err:    io.EOF,
+	}
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	done := make(chan Event, 1)
+	req := MustBuild(NewTransactionIDSetter(resp.TransactionID), BindingRequest)
+	require.NoError(t, client.Start(req, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		require.NoError(t, e.Error)
+		require.NotNil(t, e.Message)
+	case <-time.After(time.Second):
+		assert.FailNow(t, "message delivered together with EOF was not processed")
+	}
+}
+
+// TestClientReadMalformedStream verifies that garbage on a stream stops the
+// read loop, leaving the in-flight transaction to time out.
+func TestClientReadMalformedStream(t *testing.T) {
+	// A 20-byte "message" with an invalid magic cookie.
+	raw := make([]byte, messageHeaderSize)
+	binary.BigEndian.PutUint32(raw[4:8], 0xdeadbeef)
+	conn := &streamReaderConnection{
+		chunks: [][]byte{raw},
+	}
+	client, err := NewClient(conn,
+		WithLoggerFactory(logging.NewDefaultLoggerFactory()),
+		WithRTO(100*time.Millisecond),
+	)
+	require.NoError(t, err)
+	WithNoRetransmit(client)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	done := make(chan Event, 1)
+	req := MustBuild(TransactionID, BindingRequest)
+	require.NoError(t, client.Start(req, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		require.ErrorIs(t, e.Error, ErrTransactionTimeOut)
+	case <-time.After(time.Second):
+		assert.FailNow(t, "transaction was not terminated after malformed stream data")
+	}
+}
+
+// nilAddrConnection reports a nil local address, so the client must fall
+// back to datagram handling without crashing.
+type nilAddrConnection struct {
+	testConnection
+}
+
+func (c *nilAddrConnection) LocalAddr() net.Addr {
+	return nil
+}
+
+// TestClientReadNilLocalAddr verifies that a connection with a nil local
+// address is handled like a datagram connection.
+func TestClientReadNilLocalAddr(t *testing.T) {
+	resp, raw := makeResponseWithData(t, 100)
+	conn := &nilAddrConnection{
+		testConnection: testConnection{
+			b: raw,
+			write: func(b []byte) (int, error) {
+				return len(b), nil
+			},
+		},
+	}
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+
+	done := make(chan Event, 1)
+	req := MustBuild(NewTransactionIDSetter(resp.TransactionID), BindingRequest)
+	require.NoError(t, client.Start(req, func(e Event) {
+		done <- e
+	}))
+
+	select {
+	case e := <-done:
+		require.NoError(t, e.Error)
+		require.NotNil(t, e.Message)
+	case <-time.After(time.Second):
+		assert.FailNow(t, "datagram fallback for nil local address was not delivered")
+	}
+}

--- a/message.go
+++ b/message.go
@@ -27,9 +27,29 @@ const (
 	attributeHeaderSize = 4
 	messageHeaderSize   = 20
 
+	// maxMessageSize is the maximum possible STUN message size:
+	// the 20-byte header plus a body of up to 65535 bytes as encoded
+	// in the 16-bit message length field (RFC 5389 section 6).
+	maxMessageSize = messageHeaderSize + 0xffff
+
 	// TransactionIDSize is length of transaction id array (in bytes).
 	TransactionIDSize = 12 // 96 bit
 )
+
+// fullSTUNMessageSize returns the total size of the complete STUN message
+// at the start of buf (header plus body length from the length field), and
+// whether buf currently contains that many bytes.
+func fullSTUNMessageSize(buf []byte) (int, bool) {
+	if len(buf) < messageHeaderSize {
+		return 0, false
+	}
+	size := messageHeaderSize + int(bin.Uint16(buf[2:4]))
+	if len(buf) < size {
+		return 0, false
+	}
+
+	return size, true
+}
 
 // NewTransactionID returns new random transaction ID using crypto/rand
 // as source.
@@ -377,6 +397,11 @@ func (m *Message) WriteTo(w io.Writer) (int64, error) {
 // ReadFrom implements ReaderFrom. Reads message from r into m.Raw,
 // Decodes it and return error if any. If m.Raw is too small, will return
 // ErrUnexpectedEOF, ErrUnexpectedHeaderEOF or *DecodeErr.
+//
+// ReadFrom performs a single read and expects the whole message in it,
+// which matches datagram semantics (UDP, DTLS). Stream connections may
+// fragment or coalesce messages, so they must be handled by Client, which
+// reassembles complete messages before decoding.
 //
 // Can return *DecodeErr while decoding too.
 func (m *Message) ReadFrom(r io.Reader) (int64, error) {


### PR DESCRIPTION
This PR fixes two issues in the client read loop.

## 1. Exit read loop on permanent connection error

Client.readUntilClosed ignores read errors, so once the peer closes the connection the loop spins at ~200M Read calls/sec (reproduced: 25M calls in 100ms), pinning a CPU until the client is closed.

The connection is unusable after a read error anyway: the peer may have closed it, or a stream transport may be out of sync. Exiting the loop lets the existing timeout collector terminate in-flight transactions, so the client stays consistent with RFC 5389 RTO semantics.

## 2. Read large and fragmented messages on streams

The client read a single 1024-byte buffer per message, which:
- truncated messages larger than the buffer, and
- desynchronized stream connections (TCP/TLS) whenever the server fragmented or coalesced messages.

Datagram connections now use a buffer sized to the largest possible STUN message (20-byte header + 65535-byte body). Stream connections are detected via LocalAddr and messages are reassembled from the 16-bit length field before decoding, handling fragmentation, coalescing and a final message delivered together with EOF.

## Tests

Added regression tests covering both fixes:
- read loop exits on EOF (with and without a logger), transactions still time out afterward
- large messages on TCP and datagram connections
- fragmented messages on TCP
- coalesced messages on TCP
- final message delivered together with EOF
- malformed stream data stops the loop
- strict mode rejects reserved message type 0

All modified lines are covered by tests; the full suite, -race, golangci-lint and the wasm build pass.