### PR TITLE
Update to DTLS v4

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func DialURI(uri *URI, cfg *DialConfig) (*Client, error) { //nolint:cyclop
 
 		dtlsOptions := append([]dtls.ClientOption{}, cfg.DTLSOptions...)
 		dtlsOptions = append(dtlsOptions, dtls.WithServerName(uri.Host))
-		dtlsConn, err := dtls.ClientWithOptions(udpConn, udpConn.RemoteAddr(), dtlsOptions...)
+		dtlsConn, err := dtls.Client(udpConn, udpConn.RemoteAddr(), dtlsOptions...)
 		if err != nil {
 			_ = udpConn.Close()
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pion/stun/v4
 go 1.24.0
 
 require (
-	github.com/pion/dtls/v3 v3.1.8
+	github.com/pion/dtls/v3 v3.1.3-0.20260902001837-a2624993668b
 	github.com/pion/logging v0.2.4
 	github.com/pion/transport/v4 v4.1.0
 	github.com/stretchr/testify v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/pion/dtls/v3 v3.1.8 h1:aLcgjZqzrYn5AbjSds4LvK2WI5VzJc1PencExyDjYis=
-github.com/pion/dtls/v3 v3.1.8/go.mod h1:gz1K4jg6c+fq86oQMH4pilpCEOEPwmEr2jY+VcF/mkU=
+github.com/pion/dtls/v3 v3.1.3-0.20260902001837-a2624993668b h1:yx76gnoJL4Sqac6IK7phHz4bV3+MG1dUEq7ZIarBmgY=
+github.com/pion/dtls/v3 v3.1.3-0.20260902001837-a2624993668b/go.mod h1:Ug7KRZBBmMPxSK4VsWElXgEpLdYZLAQexak0zzDtbE0=
 github.com/pion/logging v0.2.4 h1:tTew+7cmQ+Mc1pTBLKH2puKsOvhm32dROumOZ655zB8=
 github.com/pion/logging v0.2.4/go.mod h1:DffhXTKYdNZU+KtJ5pyQDjvOAh/GsNSyv1lbkFbe3so=
 github.com/pion/transport/v4 v4.1.0 h1:8S+nF2reM2cJuqC6g78OVy2BBgmbdns+acx3jA97BvQ=


### PR DESCRIPTION
#### Description
Other than breaking STUN's public API in #284 once we tag dtls@v4 we'll need to merge this to switch from the transient v3 `ClientWithOptions` to options first `Client`.
This will should be merged after #284 and after both stun@v4 and dtls@v4 are tagged.